### PR TITLE
Set sans-serif as a fallback font family

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,7 +32,7 @@ html, body{
 }
 
 .non-element {
-    font-family: "HelveticaNeue-CondensedBold";
+    font-family: "HelveticaNeue-CondensedBold", sans-serif;
     font-weight: 900;
     font-size: 3.5rem;
     line-height: 5rem;
@@ -52,7 +52,7 @@ html, body{
 }
 
 .element > .symbol {
-    font-family: "HelveticaNeue-CondensedBold";
+    font-family: "HelveticaNeue-CondensedBold", sans-serif;
     font-weight: 800;
     font-size: 6.2rem;
     font-weight: bold;
@@ -65,7 +65,7 @@ html, body{
 }
 
 .element > .number {
-    font-family: "HelveticaNeue";
+    font-family: "HelveticaNeue", sans-serif;
     font-weight: 800;
     font-size: 2rem;
     line-height: 2.2rem;
@@ -73,7 +73,7 @@ html, body{
 }
 
 .element > .weight {
-    font-family: "HelveticaNeue";
+    font-family: "HelveticaNeue", sans-serif;
     font-weight: 800;
     font-size: 1.6rem;
     line-height: 1.8rem;
@@ -81,7 +81,7 @@ html, body{
 }
 
 .element > .name {
-    font-family: "HelveticaNeue-CondensedBlack";
+    font-family: "HelveticaNeue-CondensedBlack", sans-serif;
     font-weight: 900;
     font-size: 1.6rem;
     transform: scaleX(0.8);


### PR DESCRIPTION
Specify `sans-serif` as a fallback font family for users with no Helvetica Neue installed since Helvetica Neue is a sans-serif font.

No fallback font specified (Noto Serif is used as the fallback font in my system):
![noto-serif](https://user-images.githubusercontent.com/31244102/156426882-cd6cc543-35b1-42af-a508-a170befd2074.png)

With `sans-serif` fallback (Noto Sans in my system):
![noto-sans](https://user-images.githubusercontent.com/31244102/156427396-f444a5ad-a176-49ce-833b-57d23ba54f8d.png)

This is not perfect (especially overflows in areas where condensed font style is supposed to be used), but at least provides a better experience for users until proper fallback font (preferably loaded remotely) is set.